### PR TITLE
Apply statistical distributions to clicks

### DIFF
--- a/AutoClicker/AutoClicker.csproj
+++ b/AutoClicker/AutoClicker.csproj
@@ -56,6 +56,9 @@
     <Reference Include="CommonServiceLocator, Version=2.0.6.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
       <HintPath>packages\CommonServiceLocator.2.0.6\lib\net48\CommonServiceLocator.dll</HintPath>
     </Reference>
+    <Reference Include="MathNet.Numerics, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\MathNet.Numerics.5.0.0\lib\net48\MathNet.Numerics.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>

--- a/AutoClicker/packages.config
+++ b/AutoClicker/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="2.0.6" targetFramework="net48" />
+  <package id="MathNet.Numerics" version="5.0.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net48" />
   <package id="Prism" version="4.1.0.0" targetFramework="net452" />
   <package id="Serilog" version="2.10.0" targetFramework="net48" />


### PR DESCRIPTION
Wanted to hook it up to the GUI, but am not as familiar with C#. Perhaps you can give me some tips or commit to the PR as well.
As such, the standard deviation value is hard-coded for now. 

PR uses existing interval entry to define desired average CPS. Along with the, currently, hard-coded standard deviation, a normal distribution is generated for the target CPS which is used to assign timer intervals at command start and in the timer elapsed callback.

Long term, it'd be neat if different statistical distributions could be applied.

Tested out the changes, and they work as expected, though I believe I'm seeing slightly lower CPS overall. For example, tested with targeted CPS=13.33, STD_DEV=0.25, but would often see averages closer to 12.4. Did not see any higher than target CPS. Maybe I was just very very unlucky.... 

I suspect the timer callback blocks the timer from being re-armed, and perhaps the new logic is adding some more delay. Which brings me to a somewhat unrelated topic as to whether it'd be handy to profile and discount program runtimes when calculating new timer interval. Thoughts?

If the distribution logic is taking too long in timer callback and offsetting the time, could buffer N CPS samples ahead in some separate thread, so that timer callback can just O(1) lookup the value instead. However, I'd like to get back to gaming now lol.